### PR TITLE
Run command vdelivery

### DIFF
--- a/vdelivermail.c
+++ b/vdelivermail.c
@@ -994,13 +994,8 @@ void (*f)();
  */
 void run_command(const char *prog) {
   int child; 
-  int wstat;  
-  char *const args[] = { 
-    "/bin/sh", 
-    "-c", 
-    (char *)prog, 
-    NULL 
-  };
+  int wstat; 
+  char *(args[4]);	
 
   while ((*prog == ' ') || (*prog == '|')) ++prog;
 
@@ -1010,6 +1005,7 @@ void run_command(const char *prog) {
       vexit(EXIT_DEFER);
     case 0:
       putenv("SHELL=/bin/sh");
+			args[0] = "/bin/sh"; args[1] = "-c"; args[2] = prog; args[3] = NULL;
       sig_catch(SIGPIPE, SIG_DFL);
       execv(*args, args);
       printf("Unable to run /bin/sh: %d.", errno);

--- a/vdelivermail.c
+++ b/vdelivermail.c
@@ -997,7 +997,7 @@ void run_command(const char *prog) {
   int wstat; 
   char *(args[4]);	
 
-      while ((*prog == ' ') || (*prog == '|')) ++prog;
+  while ((*prog == ' ') || (*prog == '|')) ++prog;
 
   switch (child = fork()) {
     case -1:

--- a/vdelivermail.c
+++ b/vdelivermail.c
@@ -997,7 +997,7 @@ void run_command(const char *prog) {
   int wstat; 
   char *(args[4]);	
 
-  while ((*prog == ' ') || (*prog == '|')) ++prog;
+      while ((*prog == ' ') || (*prog == '|')) ++prog;
 
   switch (child = fork()) {
     case -1:
@@ -1005,7 +1005,7 @@ void run_command(const char *prog) {
       vexit(EXIT_DEFER);
     case 0:
       putenv("SHELL=/bin/sh");
-			args[0] = "/bin/sh"; args[1] = "-c"; args[2] = prog; args[3] = NULL;
+      args[0] = "/bin/sh"; args[1] = "-c"; args[2] = prog; args[3] = NULL;
       sig_catch(SIGPIPE, SIG_DFL);
       execv(*args, args);
       printf("Unable to run /bin/sh: %d.", errno);

--- a/vqmaillocal.c
+++ b/vqmaillocal.c
@@ -650,8 +650,7 @@ void run_command(char *prog)
  char *(args[4]);
  int wstat;
 
- while (*prog==' ') ++prog;
- while (*prog=='|') ++prog;
+ while ((*prog == ' ') || (*prog == '|')) ++prog;
 
     if ( lseek(0, 0L, SEEK_SET) < 0 ) {
         printf("lseek errno=%d\n", errno);


### PR DESCRIPTION
Change creation order of args.
We need to remove | or ' ' before creating the args[] for sh, otherwise | will be an argument of bash.