### PR TITLE
Remove pw_passwd prefix like {SHA512-CRYPT}

### DIFF
--- a/vcdb.c
+++ b/vcdb.c
@@ -1311,9 +1311,17 @@ void vcdb_strip_char( char *instr )
 int vauth_crypt(char *user,char *domain,char *clear_pass,struct vqpasswd *vpw)
 {
   const char *c;
+	const char *p;
   if ( vpw == NULL ) return(-1);
-
-  c = crypt(clear_pass,vpw->pw_passwd);
+	p = vpw->pw_passwd;
+	
+  /* if needed remove {XXX-CRYPT}$ */
+	if (p[0] == '{') {
+		const char *k = strchr(p, '}');
+		if (k != NULL) p = k + 1;
+	}
+	
+  c = crypt(clear_pass, p);
   if (c == NULL) return (-1);
-  return(strcmp(c,vpw->pw_passwd));
+  return(strcmp(c, p));
 }

--- a/vldap.c
+++ b/vldap.c
@@ -1464,11 +1464,19 @@ void *safe_malloc(size_t siz) {
 int vauth_crypt(char *user, char *domain, char *clear_pass,
                 struct vqpasswd *vpw) {
   const char *c;
-  if (vpw == NULL) return (-1);
-
-  c = crypt(clear_pass, vpw->pw_passwd);
+	const char *p;
+  if ( vpw == NULL ) return(-1);
+	p = vpw->pw_passwd;
+	
+  /* if needed remove {XXX-CRYPT}$ */
+	if (p[0] == '{') {
+		const char *k = strchr(p, '}');
+		if (k != NULL) p = k + 1;
+	}
+	
+  c = crypt(clear_pass, p);
   if (c == NULL) return (-1);
-  return (strcmp(c, vpw->pw_passwd));
+  return(strcmp(c, p));
 }
 
 /***************************************************************************/

--- a/vmysql.c
+++ b/vmysql.c
@@ -1907,11 +1907,19 @@ int vdel_limits(const char *domain)
 int vauth_crypt(char *user,char *domain,char *clear_pass,struct vqpasswd *vpw)
 {
   const char *c;
+	const char *p;
   if ( vpw == NULL ) return(-1);
-
-  c = crypt(clear_pass,vpw->pw_passwd);
+	p = vpw->pw_passwd;
+	
+  /* if needed remove {XXX-CRYPT}$ */
+	if (p[0] == '{') {
+		const char *k = strchr(p, '}');
+		if (k != NULL) p = k + 1;
+	}
+	
+  c = crypt(clear_pass, p);
   if (c == NULL) return (-1);
-  return(strcmp(c,vpw->pw_passwd));
+  return(strcmp(c, p));
 }
 
 

--- a/vpgsql.c
+++ b/vpgsql.c
@@ -1841,11 +1841,19 @@ void vcreate_vlog_table()
 
 int vauth_crypt(char *user,char *domain,char *clear_pass,struct vqpasswd *vpw)
 {
-    const char *c;
-    if ( vpw == NULL ) return(-1);
-
-    c = crypt(clear_pass,vpw->pw_passwd);
-    if (c == NULL) return(-1);
-	return(strcmp(c,vpw->pw_passwd));
+  const char *c;
+	const char *p;
+  if ( vpw == NULL ) return(-1);
+	p = vpw->pw_passwd;
+	
+  /* if needed remove {XXX-CRYPT}$ */
+	if (p[0] == '{') {
+		const char *k = strchr(p, '}');
+		if (k != NULL) p = k + 1;
+	}
+	
+  c = crypt(clear_pass, p);
+  if (c == NULL) return (-1);
+  return(strcmp(c, p));
 }
 

--- a/vsqlite.c
+++ b/vsqlite.c
@@ -1657,9 +1657,17 @@ int vdel_limits(const char *domain) {
 int vauth_crypt(char *user, char *domain, char *clear_pass,
                 struct vqpasswd *vpw) {
   const char *c;
-  if (vpw == NULL) return (-1);
-
-  c = crypt(clear_pass, vpw->pw_passwd);
+	const char *p;
+  if ( vpw == NULL ) return(-1);
+	p = vpw->pw_passwd;
+	
+  /* if needed remove {XXX-CRYPT}$ */
+	if (p[0] == '{') {
+		const char *k = strchr(p, '}');
+		if (k != NULL) p = k + 1;
+	}
+	
+  c = crypt(clear_pass, p);
   if (c == NULL) return (-1);
-  return (strcmp(c, vpw->pw_passwd));
+  return(strcmp(c, p));
 }

--- a/vsybase.c
+++ b/vsybase.c
@@ -646,9 +646,17 @@ int vshow_ip_map( int first, char *ip, char *domain);
 int vauth_crypt(char *user,char *domain,char *clear_pass,struct vqpasswd *vpw)
 {
   const char *c;
+	const char *p;
   if ( vpw == NULL ) return(-1);
-
-  c = crypt(clear_pass,vpw->pw_passwd);
-  if (c == NULL) return -1;
-  return(strcmp(c,vpw->pw_passwd));
+	p = vpw->pw_passwd;
+	
+  /* if needed remove {XXX-CRYPT}$ */
+	if (p[0] == '{') {
+		const char *k = strchr(p, '}');
+		if (k != NULL) p = k + 1;
+	}
+	
+  c = crypt(clear_pass, p);
+  if (c == NULL) return (-1);
+  return(strcmp(c, p));
 }


### PR DESCRIPTION
Dovecot (maybe others) allow to use multiple crypt scheme but they had to be prefixed by {XXXX-CRYPT} if is not the default scheme.
As this way of writing is common (in ldap by exemple) but accepted by crypt, i remove it before passing the pw_passwd to crypt.

It's usefull for changing the default crypt scheme without forcing users to change they password.