### PR TITLE
Remove valias primary key

### DIFF
--- a/vmysql.h
+++ b/vmysql.h
@@ -245,12 +245,15 @@ level_index0, level_index1, level_index2, the_dir"
 
 #ifdef DEFAULT_DELIVERY
 #define VALIAS_TABLE_LAYOUT \
-"valias_type tinyint(1) NOT NULL DEFAULT 1 COMMENT '1=forwarder 0=lda', \
+"id INT NOT NULL AUTO_INCREMENT, \
+valias_type tinyint(1) NOT NULL DEFAULT 1 COMMENT '1=forwarder 0=lda', \
 alias char(32) NOT NULL, \
 domain char(96) NOT NULL, \
 valias_line text NOT NULL, \
 copy tinyint(1) NOT NULL DEFAULT 0 COMMENT '0=redirect 1=copy&redirect', \
-INDEX (alias, domain)"
+INDEX (alias, domain), \
+INDEX (alias, domain, valias_type), \
+PRIMARY KEY (id)"
 #else
 #define VALIAS_TABLE_LAYOUT "id int(11) PRIMARY KEY AUTO_INCREMENT, \
 alias char(32) NOT NULL, \

--- a/vmysql.h
+++ b/vmysql.h
@@ -250,7 +250,6 @@ alias char(32) NOT NULL, \
 domain char(96) NOT NULL, \
 valias_line text NOT NULL, \
 copy tinyint(1) NOT NULL DEFAULT 0 COMMENT '0=redirect 1=copy&redirect', \
-PRIMARY KEY (alias,domain,valias_type), \
 INDEX (alias, domain)"
 #else
 #define VALIAS_TABLE_LAYOUT "id int(11) PRIMARY KEY AUTO_INCREMENT, \


### PR DESCRIPTION
The primary key block the insertion of  a second valias row with the same alias/domain.